### PR TITLE
Remove KFF (KFFData): policy org, not a newsroom

### DIFF
--- a/orgs.csv
+++ b/orgs.csv
@@ -161,7 +161,6 @@ Journal News (White Plains N.Y.),Newsroom,https://github.com/lohud
 Journalism++,News Industry,https://github.com/jplusplus
 JournalismAI,News Industry,https://github.com/JournalismAI
 Kaiser Health News,Newsroom,https://github.com/khnews
-KFF Data,News Industry,https://github.com/KFFData
 Kiln,News Industry,https://github.com/kiln
 KPBS,Newsroom,https://github.com/KPBS
 KQED San Francisco,Newsroom,https://github.com/kqed


### PR DESCRIPTION
KFF (formerly the Kaiser Family Foundation) is a health-policy research and think-tank organization, not a news organization. Its GitHub account, [KFFData](https://github.com/KFFData), was listed under "News Industry" in `orgs.csv`, but it does not belong in a list of news organizations.

This PR removes only the `KFF Data` row.

**Kaiser Health News (`khnews`) is intentionally retained.** KHN is a legitimate, editorially independent newsroom (now part of KFF Health News) and remains in the list. Only the policy/research org (KFFData) is removed; the newsroom (khnews) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)