### PR TITLE
Add 7 newsroom GitHub orgs discovered via the Videofy ecosystem

### DIFF
--- a/orgs.csv
+++ b/orgs.csv
@@ -8,6 +8,7 @@ Aftenposten (Norway),Newsroom,https://github.com/aftenposten
 AJ+,Newsroom,https://github.com/ALJAZEERAPLUS
 AJAM,Newsroom,https://github.com/ajam
 Al Jazeera Interactive,Newsroom,https://github.com/ajinteractive
+Aller Media (Scandinavia),Newsroom,https://github.com/allermedia
 American Public Media,Newsroom,https://github.com/APMG
 Animal Politico,Newsroom,https://github.com/animalpolitico
 Arizona Daily Star,Newsroom,https://github.com/arizonadailystar
@@ -165,6 +166,7 @@ KFF Data,News Industry,https://github.com/KFFData
 Kiln,News Industry,https://github.com/kiln
 KPBS,Newsroom,https://github.com/KPBS
 KQED San Francisco,Newsroom,https://github.com/kqed
+KURIER (Austria),Newsroom,https://github.com/kurier
 LAist (Southern California Public Radio),Newsroom,https://github.com/SCPR
 La Nación (Buenos Aires),Newsroom,https://github.com/lanacioncom
 La Opinión,Newsroom,https://github.com/laopinion
@@ -228,6 +230,7 @@ NRK (Norway),Newsroom,https://github.com/nrkno
 NZZ,Newsroom,https://github.com/nzzdev
 OCCRP,Newsroom,https://github.com/occrp
 OCCRP Aleph,News Industry,https://github.com/alephdata
+Omni (Sweden),Newsroom,https://github.com/omninews
 Onion,Newsroom,https://github.com/theonion
 Open Newswire,News Industry,https://github.com/Open-Newswire
 OpenAleph,News Industry,https://github.com/openaleph
@@ -241,10 +244,12 @@ Open Secrets,Newsroom,https://github.com/opensecrets
 Overview Project,News Industry,https://github.com/overview
 Palm Beach Post,Newsroom,https://github.com/PalmBeachPost
 PBS NewsHour,Newsroom,https://github.com/newshour
+Petit Press (Slovakia),Newsroom,https://github.com/petitpress
 Philly.com,Newsroom,https://github.com/phillymedia
 Pitch Interactive,News Industry,https://github.com/PitchInteractiveInc
 Pitchfork,Newsroom,https://github.com/pitchfork
 Poderopedia,News Industry,https://github.com/poderopedia
+Polaris Media (Norway),Newsroom,https://github.com/polaris-media
 PolicyMic,News Industry,https://github.com/policymic
 Politibot,News Industry,https://github.com/politibot
 Politico,Newsroom,https://github.com/the-politico
@@ -263,6 +268,7 @@ Quartz,Newsroom,https://github.com/quartz
 Quartz Bot Studio,Newsroom,https://github.com/quartz-bot-studio
 Radio France,Newsroom,https://github.com/radiofrance
 Radio Free Europe/Radio Liberty,Newsroom,https://github.com/rferl
+Radio Milwaukee (US),Newsroom,https://github.com/radiomilwaukee
 Rappler,Newsroom,https://github.com/TheRapplers
 Recovered Factory,News Industry,https://github.com/recoveredfactory
 Reese News Lab,News Industry,https://github.com/reesenewslab
@@ -300,6 +306,7 @@ States Newsroom Engineering,Newsroom,https://github.com/statesnewsroom-eng
 Storyful,News Industry,https://github.com/storyful
 SunlightLabs,News Industry,https://github.com/sunlightlabs
 SWR Data Lab,Newsroom,https://github.com/SWRdata
+t3n (Germany),Newsroom,https://github.com/t3n
 TagesWoche,Newsroom,https://github.com/tageswoche
 Tampa Bay Times,Newsroom,https://github.com/tbtimes
 Tarbell Project,News Industry,https://github.com/tarbell-project


### PR DESCRIPTION
Adds seven active newsroom / publisher GitHub organizations that aren't yet in \`orgs.csv\`. All seven surfaced while looking at the stargazers and forkers of [\`schibsted/videofy_minimal\`](https://github.com/schibsted/videofy_minimal) (the most-starred newsroom open-source project of 2026) — each was verified as a real, repo-active newsroom org.

| Organization | Type | GitHub | Notes |
|---|---|---|---|
| Aller Media | Newsroom | [allermedia](https://github.com/allermedia) | Leading Scandinavian magazine/weekly publisher (22 repos) |
| Petit Press | Newsroom | [petitpress](https://github.com/petitpress) | Slovak publisher, SME.sk (20 repos) — forked & customized Videofy for Slovak |
| Radio Milwaukee | Newsroom | [radiomilwaukee](https://github.com/radiomilwaukee) | US public radio, 88Nine (23 repos) |
| t3n | Newsroom | [t3n](https://github.com/t3n) | German digital/tech magazine (54 repos) |
| KURIER | Newsroom | [kurier](https://github.com/kurier) | Austrian daily |
| Polaris Media | Newsroom | [polaris-media](https://github.com/polaris-media) | Norwegian regional media group |
| Omni | Newsroom | [omninews](https://github.com/omninews) | Swedish news aggregator |

Rows inserted in alphabetical position; CRLF line endings preserved (diff is 7 additions, 0 deletions).