### PR TITLE
Add 34 newsroom GitHub orgs from Newspack/LION/INN directories

### DIFF
--- a/orgs.csv
+++ b/orgs.csv
@@ -11,10 +11,12 @@ Al Jazeera Interactive,Newsroom,https://github.com/ajinteractive
 Aller Media (Scandinavia),Newsroom,https://github.com/allermedia
 American Public Media,Newsroom,https://github.com/APMG
 Animal Politico,Newsroom,https://github.com/animalpolitico
+Arizona Center for Investigative Reporting,Newsroom,https://github.com/AZCIR
 Arizona Daily Star,Newsroom,https://github.com/arizonadailystar
 Arizona Public Media,Newsroom,https://github.com/azpm
 Arizona Republic,Newsroom,https://github.com/Arizona-Republic-Data
 Associated Press,Newsroom,https://github.com/associatedpress
+Atavist Magazine,Newsroom,https://github.com/Atavist
 Atlanta Journal-Constitution,Newsroom,https://github.com/NewsappAJC
 Atlantic,Newsroom,https://github.com/theatlantic
 Austin American-Statesman,Newsroom,https://github.com/statesman
@@ -38,6 +40,7 @@ Big Local News,News Industry,https://github.com/biglocalnews
 Bloomberg,Newsroom,https://github.com/bloomberg
 Bloomberg Graphics,Newsroom,https://github.com/bloomberggraphics
 Bloomberg Media,Newsroom,https://github.com/bloombergmedia
+Borderzine,Newsroom,https://github.com/Borderzine
 Boston Globe,Newsroom,https://github.com/bostonglobe
 Brown Institute,News Industry,https://github.com/browninstitute
 Brown Institute Local News Lab,News Industry,https://github.com/LocalAtBrown
@@ -60,14 +63,18 @@ Center for Investigative Reporting / Reveal,Newsroom,https://github.com/cirlabs
 Center for Public Integrity,Newsroom,https://github.com/publici
 Chalkbeat,Newsroom,https://github.com/Chalkbeat
 Charleston Post and Courier,Newsroom,https://github.com/postandcourier
+Charlottesville Tomorrow,Newsroom,https://github.com/cvilletomorrow
+Chicago Reader,Newsroom,https://github.com/chicagoreader
 Chicago Reporter,Newsroom,https://github.com/thechicagoreporter
 Chicago Tribune News Applications Team,Newsroom,https://github.com/newsapps
 Chronicle of Higher Ed / Philanthropy,Newsroom,https://github.com/chrondata
 City Bureau,News Industry,https://github.com/City-Bureau
 Civica Digital,News Industry,https://github.com/civica-digital
 CivicBand,News Industry,https://github.com/civicband
+CivicLex,Newsroom,https://github.com/civiclex
 CivilBeat (Honolulu),Newsroom,https://github.com/CivilBeat
 Civio,Newsroom,https://github.com/civio
+Colorado Sun,Newsroom,https://github.com/coloradosun
 Columbia Spectator,Newsroom,https://github.com/NewsroomDevelopment
 Conde Nast,Newsroom,https://github.com/condenast
 Consumer Reports,Newsroom,https://github.com/consumerreports
@@ -82,10 +89,12 @@ Daily Beast,Newsroom,https://github.com/dailybeast
 Daily Californian,Newsroom,https://github.com/dailycal-projects
 Daiy Kos,Newsroom,https://github.com/dailykos
 Daily Mail (London),Newsroom,https://github.com/MailOnline
+Daily Tar Heel,Newsroom,https://github.com/dailytarheel
 Dallas Morning News,Newsroom,https://github.com/dallasmorningnews
 Data Liberation Project,News Industry,https://github.com/data-liberation-project
 DataMade,News Industry,https://github.com/datamade
 Datawrapper,News Industry,https://github.com/datawrapper
+DC Witness,Newsroom,https://github.com/dcwitness
 Decoherence Media,Newsroom,https://github.com/decoherencemedia
 Democracy Now,Newsroom,https://github.com/DemocracyNow
 Democrat and Chronicle (Rochester N.Y.),Newsroom,https://github.com/dandc
@@ -100,6 +109,8 @@ DocumentCloud,News Industry,https://github.com/documentcloud
 Dow Jones,Newsroom,https://github.com/dowjones
 Drone Journalism Lab,News Industry,https://github.com/DroneJournalismLab
 Duke Chronicle,Newsroom,https://github.com/dukechronicle
+EdSource,Newsroom,https://github.com/edsource
+EdSurge,Newsroom,https://github.com/edsurge
 El Faro,Newsroom,https://github.com/el-faro
 El Pais,Newsroom,https://github.com/elpais
 EveryBlock,News Industry,https://github.com/everyblock
@@ -147,13 +158,17 @@ Howard Center for Investigative Journalism,News Industry,https://github.com/Howa
 ICIJ,Newsroom,https://github.com/icij
 iMEdD (Athens),Newsroom,https://github.com/iMEdD-Lab
 IndiaSpend,News Industry,https://github.com/indiaspend
+inewsource,Newsroom,https://github.com/inewsource
 InfoAmazonia,Newsroom,https://github.com/InfoAmazonia
+InformUp,Newsroom,https://github.com/INFORMUP
 Initium Lab 端傳媒,Newsroom,https://github.com/initiumlab
+Injustice Watch,Newsroom,https://github.com/injusticewatch
 Inside Climate News,Newsroom,https://github.com/InsideClimateNews
 Inside Energy,Newsroom,https://github.com/InsideEnergy
 Institute for Nonprofit News (INN),News Industry,https://github.com/inn
 International Center for Journalists,News Industry,https://github.com/icfj-org
 Internews in Kenya,News Industry,https://github.com/internews-ke
+Investigative Post,Newsroom,https://github.com/investigativepost
 Investigative Reporting Workshop,News Industry,https://github.com/irworkshop
 Invisible Institute,News Industry,https://github.com/invinst
 IRE/NICAR,News Industry,https://github.com/ireapps
@@ -168,6 +183,7 @@ KQED San Francisco,Newsroom,https://github.com/kqed
 KURIER (Austria),Newsroom,https://github.com/kurier
 LAist (Southern California Public Radio),Newsroom,https://github.com/SCPR
 La Nación (Buenos Aires),Newsroom,https://github.com/lanacioncom
+La Noticia (N.C.),Newsroom,https://github.com/lanoticia
 La Opinión,Newsroom,https://github.com/laopinion
 Lawrence Journal-World,Newsroom,https://github.com/worldcompany
 Le Monde,Newsroom,https://github.com/lemonde
@@ -185,6 +201,7 @@ McClatchy Southeast Data Desk,Newsroom,https://github.com/mcclatchy-southeast
 Meedan,News Industry,https://github.com/meedan
 Miami Herald,Newsroom,https://github.com/miamiherald
 Mic News,Newsroom,https://github.com/micnews
+Michigan Daily,Newsroom,https://github.com/michigandaily
 Michigan Radio,Newsroom,https://github.com/michiganradio
 Milwaukee Journal Sentinel Data Hub,Newsroom,https://github.com/datahub
 Minneapolis Star Tribune,Newsroom,https://github.com/minneapolisstartribune
@@ -192,7 +209,10 @@ Minneapolis Star Tribune Lab,Newsroom,https://github.com/striblab
 MinnPost,Newsroom,https://github.com/minnpost
 Mirror Media 鏡傳媒,Newsroom,https://github.com/mirror-media
 Mission Local,Newsroom,https://github.com/MissionLocal
+Mississippi Free Press,Newsroom,https://github.com/mississippifreepress
+Mississippi River Basin Ag & Water Desk,Newsroom,https://github.com/agwaterdesk
 MIT Technology Review,Newsroom,https://github.com/technologyreview
+Mongabay,Newsroom,https://github.com/mongabay
 Montana Free Press,Newsroom,https://github.com/mtfreepress
 Mother Jones,Newsroom,https://github.com/motherjones
 Muck Rack,News Industry,https://github.com/muckrack
@@ -201,6 +221,7 @@ Nation Media Group (Nairobi),Newsroom,https://github.com/NMG-Digital
 National Geographic Partners,Newsroom,https://github.com/natgeo
 National Geographic Society,Newsroom,https://github.com/natgeosociety
 NBC News,Newsroom,https://github.com/nbcnews
+New Mexico In Depth,Newsroom,https://github.com/nmindepth
 New Scientist,Newsroom,https://github.com/newscientistapps
 The 19th,Newsroom,https://github.com/The-19th
 The 51st,Newsroom,https://github.com/the51stnews
@@ -229,6 +250,7 @@ NRK (Norway),Newsroom,https://github.com/nrkno
 NZZ,Newsroom,https://github.com/nzzdev
 OCCRP,Newsroom,https://github.com/occrp
 OCCRP Aleph,News Industry,https://github.com/alephdata
+Oklahoma Watch,Newsroom,https://github.com/oklahomawatch
 Omni (Sweden),Newsroom,https://github.com/omninews
 Onion,Newsroom,https://github.com/theonion
 Open Newswire,News Industry,https://github.com/Open-Newswire
@@ -242,6 +264,7 @@ Orlando Sentinel,Newsroom,https://github.com/OrlandoSentinel
 Open Secrets,Newsroom,https://github.com/opensecrets
 Overview Project,News Industry,https://github.com/overview
 Palm Beach Post,Newsroom,https://github.com/PalmBeachPost
+PBS,Newsroom,https://github.com/pbs
 PBS NewsHour,Newsroom,https://github.com/newshour
 Petit Press (Slovakia),Newsroom,https://github.com/petitpress
 Philly.com,Newsroom,https://github.com/phillymedia
@@ -259,6 +282,7 @@ POV,News Industry,https://github.com/povdocs
 Proof News,Newsroom,https://github.com/ProofNews
 ProPublica,Newsroom,https://github.com/propublica
 PRX,Newsroom,https://github.com/PRX
+Public Health Watch,Newsroom,https://github.com/publichealthwatch
 Public Ledger,News Industry,https://github.com/PublicLedger
 Public Radio International,Newsroom,https://github.com/PublicRadioInternational
 PublicSource (Pittsburgh),Newsroom,https://github.com/publicsource
@@ -273,6 +297,7 @@ Recovered Factory,News Industry,https://github.com/recoveredfactory
 Reese News Lab,News Industry,https://github.com/reesenewslab
 Register-Guard (Eugene Ore.),Newsroom,https://github.com/registerguard
 Register-Guard (Eugene Ore.),Newsroom,https://github.com/rgnewsroom
+Religion News Service,Newsroom,https://github.com/religionnews
 Reporter 報導者,Newsroom,https://github.com/twreporter
 Resolve Philly,Newsroom,https://github.com/Resolve-Philly
 Rest of World,Newsroom,https://github.com/row-engineering
@@ -289,6 +314,8 @@ Salud Con Lupa,Newsroom,https://github.com/saludconlupa
 San Antonio Express-News,Newsroom,https://github.com/sa-express-news
 San Diego Union-Tribune Data Desk,Newsroom,https://github.com/sdut-datadesk
 San Francisco Chronicle,Newsroom,https://github.com/sfchronicle
+San Francisco Public Press,Newsroom,https://github.com/SFPublicPress
+SaportaReport,Newsroom,https://github.com/saportareport
 Schibsted,Newsroom,https://github.com/schibsted
 Seattle Times,Newsroom,https://github.com/seattletimes
 Slate,Newsroom,https://github.com/slategroup
@@ -303,6 +330,7 @@ SRF Data,Newsroom,https://github.com/srfdata
 States Newsroom,Newsroom,https://github.com/statesnewsroom
 States Newsroom Engineering,Newsroom,https://github.com/statesnewsroom-eng
 Storyful,News Industry,https://github.com/storyful
+Street Roots,Newsroom,https://github.com/streetroots
 SunlightLabs,News Industry,https://github.com/sunlightlabs
 SWR Data Lab,Newsroom,https://github.com/SWRdata
 t3n (Germany),Newsroom,https://github.com/t3n
@@ -314,13 +342,17 @@ Telemundo,Newsroom,https://github.com/telemundo
 Texas Tribune,Newsroom,https://github.com/texastribune
 Texty.org.ua,Newsroom,https://github.com/texty
 The City,Newsroom,https://github.com/thecityny
+The Conversation (U.S.),Newsroom,https://github.com/TheConversation
+The Current (Louisiana),Newsroom,https://github.com/thecurrentla
 The Economist,Newsroom,https://github.com/theeconomist
 The Economist Group,Newsroom,https://github.com/economistdigitalsolutions
 The Free Lance-Star,Newsrooom,https://github.com/FreeLanceStar
 The Hilton Head Island Packet,Newsroom,https://github.com/islandpacket
+The Intercept,Newsroom,https://github.com/theintercept
 The Lens,Newsroom,https://github.com/TheLens
 The Markup,Newsroom,https://github.com/the-markup
 The Marshall Project,Newsroom,https://github.com/themarshallproject
+The New Humanitarian,Newsroom,https://github.com/thenewhumanitarian
 The Trace,Newsroom,https://github.com/TeamTrace
 Time Magazine,Newsroom,https://github.com/TimeMagazine
 Time Magazine Labs,Newsroom,https://github.com/TimeMagazineLabs
@@ -341,6 +373,7 @@ VG (Norway),Newsroom,https://github.com/vgno
 Vice Media,Newsroom,https://github.com/VICEMedia
 Voice of America,Newsroom,https://github.com/voanews
 Vox Media,Newsroom,https://github.com/voxmedia
+W42ST,Newsroom,https://github.com/w42st
 Wall Street Journal,Newsroom,https://github.com/WSJ
 Washington City Paper,Newsroom,https://github.com/washingtoncitypaper
 Washington Post,Newsroom,https://github.com/washingtonpost
@@ -358,6 +391,7 @@ WNPR (Connecticut Public Radio),Newsroom,https://github.com/wnpr
 WNYC (New York Public Radio),Newsroom,https://github.com/wnyc
 WNYC DataNews,Newsroom,https://github.com/datanews
 WRAL Data Desk,Newsroom,https://github.com/wraldata
+WyoFile,Newsroom,https://github.com/wyofile
 Yahoo! Paranoids,News Industry,https://github.com/theparanoids
 YLE (Finnish National Broadcaster),Newsroom,https://github.com/Yleisradio
 Youth Radio,Newsroom,https://github.com/youthradio


### PR DESCRIPTION
Adds 34 active newsroom / publisher GitHub organizations not yet in `orgs.csv`, discovered by cross-referencing three publisher directories against GitHub:

- **Newspack** publisher list
- **LION Publishers** active members
- **INN** (Institute for Nonprofit News) member directory

Method: each publisher's website domain was matched to a GitHub org (domain → handle), then verified by (a) the account's blog field pointing back to the publisher domain and (b) the org owning real non-fork repos. Handle collisions (e.g. unrelated companies sharing a name) and placeholder-only accounts were filtered out by hand.

Highlights in this batch: **Mongabay**, **The Intercept**, **The New Humanitarian**, **Michigan Daily**, **PBS**, **EdSource**, **Religion News Service**, plus a deep bench of investigative/local nonprofits (Oklahoma Watch, AZCIR, inewsource, Investigative Post, Borderzine, Injustice Watch, Public Health Watch, Colorado Sun, Mississippi Free Press, and more).

All rows typed `Newsroom`, inserted alphabetically; CRLF line endings preserved (diff is 34 additions, 0 deletions).