### PR TITLE
Add Diagram Chasing (India)

### DIFF
--- a/orgs.csv
+++ b/orgs.csv
@@ -103,6 +103,7 @@ Der Spiegel,Newsroom,https://github.com/DerSpiegel
 Der Spiegel Graphics,Newsroom,https://github.com/spiegelgraphics
 Deseret News,Newsroom,https://github.com/deseretnews
 Deutsche Welle Data,Newsroom,https://github.com/dw-data
+Diagram Chasing (India),Newsroom,https://github.com/diagram-chasing
 Digital First Media Thunderdome,Newsroom,https://github.com/thunderdome-data
 DNAinfo,Newsroom,https://github.com/DNAinfo
 DocumentCloud,News Industry,https://github.com/documentcloud


### PR DESCRIPTION
Closes #75. Independent India-focused data-journalism / civic-tech collective ([diagram-chasing](https://github.com/diagram-chasing), 19 repos) — e.g. the film-censorship database [cbfc.watch](https://cbfc.watch/), covered by The Hindu's Frontline and IndieWire. Inserted alphabetically; CRLF preserved (1 addition, 0 deletions).