### PR TITLE
Remove PBS (broadcaster infra, not a newsroom)

### DIFF
--- a/orgs.csv
+++ b/orgs.csv
@@ -264,7 +264,6 @@ Orlando Sentinel,Newsroom,https://github.com/OrlandoSentinel
 Open Secrets,Newsroom,https://github.com/opensecrets
 Overview Project,News Industry,https://github.com/overview
 Palm Beach Post,Newsroom,https://github.com/PalmBeachPost
-PBS,Newsroom,https://github.com/pbs
 PBS NewsHour,Newsroom,https://github.com/newshour
 Petit Press (Slovakia),Newsroom,https://github.com/petitpress
 Philly.com,Newsroom,https://github.com/phillymedia


### PR DESCRIPTION
PBS was added in #78 but `github.com/pbs` is PBS's general engineering org (HLS streaming, Hulu content API, CI tooling), not newsroom code. PBS NewsHour is already tracked separately as `github.com/newshour`. Removes the one row (0 additions, 1 deletion; CRLF preserved).